### PR TITLE
Specify title of app only in manifest.yml

### DIFF
--- a/form.yml
+++ b/form.yml
@@ -10,9 +10,6 @@
 #     cluster: "owens"
 cluster: ""
 
-# Title of the app displayed in the Dashboard
-title: "Jupyter Notebook"
-
 # Description of the app displayed in the Dashboard (can use multi-line string
 # and Markdown syntax)
 description: |

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,5 +1,5 @@
 ---
-name: Jupyter
+name: Jupyter Notebook
 category: Interactive Apps
 subcategory: Servers
 role: batch_connect


### PR DESCRIPTION
The only benefit of specifying the title in the form.yml is when we have "subapps", where each subapp needs a different title; otherwise the manifest.yml can be used. This way we can maintain for all our apps that the basic way you change the title of the app is to specify name in the manifest.

Otherwise its confusing because I change the name of the app in the manifest.yml and it has no effect if the title is specified in the form.yml.