### PR TITLE
[DO NOT MERGE] Example: Custom environment

### DIFF
--- a/form.yml
+++ b/form.yml
@@ -11,7 +11,7 @@
 cluster: "owens"
 
 # Title of the app displayed in the Dashboard
-title: "Jupyter Notebook"
+title: "Jupyter Notebook (example)"
 
 # Description of the app displayed in the Dashboard (can use multi-line string
 # and Markdown syntax)
@@ -33,7 +33,15 @@ attributes:
   #     modules: "python/3.5"
   # @example Using combination of modules
   #     modules: "python/3.5 cuda/8.0.44"
-  modules: "python"
+  custom_environment:
+    widget: text_area
+    label: Environment Setup
+    value: |
+      # Restore module environment to avoid conflicts
+      module restore
+
+      # Load required modules
+      module load python/3.5
 
   # Whether Conda extensions will be available within the Jupyter notebook
   # server
@@ -61,7 +69,7 @@ attributes:
 #   option, then it will not appear in the form page that the user sees in the
 #   Dashboard
 form:
-  - modules
+  - custom_environment
   - conda_extensions
   - extra_jupyter_args
   - bc_num_hours

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -6,14 +6,7 @@ cd "${HOME}"
 #
 # Start Jupyter Notebook Server
 #
-
-<%- unless context.modules.blank? -%>
-# Restore the module environment to avoid conflicts
-module restore
-
-# Load the require modules
-module load <%= context.modules %>
-<%- end -%>
+<%= context.custom_environment %>
 
 # Launch the Jupyter Notebook Server
 jupyter notebook --config="${CONFIG_FILE}" <%= context.extra_jupyter_args %>


### PR DESCRIPTION
This shows how you could use a text area to provide a customizable environment setup prior to starting Jupyter notebook server. 

[Current limitations of the batch connect plugin](https://github.com/OSC/ood-dashboard/issues/376) prevent from modifying the size of the text area, so until that is fixed this may not be an ideal user experience, as the default text area is small. But some browsers do allow manually resizing, as I have done in this screenshot below:

![screen 2018-08-14 at 4 06 23 pm](https://user-images.githubusercontent.com/512333/44115485-0404254e-9fdc-11e8-9dbc-36b89aa239d0.png)
